### PR TITLE
Moved the base shortcut mechanism from `__call__` to `cut`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Flask-Shortcut
 
 .. image:: https://img.icons8.com/color/144/000000/cabbage.png
    :alt: Cabbage
-   :align: center
+   :align: left
 
 
 .. image:: https://github.com/a-recknagel/Flask-Shortcut/workflows/CI-CD/badge.svg
@@ -16,7 +16,7 @@ Flask-Shortcut
 
 .. image:: https://img.shields.io/badge/docs-github--pages-blue
    :alt: Documentation home
-   :target: https://a-recknagel.github.io/flask-shortcut/
+   :target: https://a-recknagel.github.io/Flask-Shortcut/
 
 .. image:: https://img.shields.io/pypi/l/flask-shortcut
    :alt: Package license

--- a/flask_shortcut/logic.py
+++ b/flask_shortcut/logic.py
@@ -1,5 +1,6 @@
 from logging import getLogger
-from typing import Union, Tuple, Dict, Any
+from typing import Union, Tuple, Dict, Any, Optional
+from types import MethodType
 from functools import wraps
 import json
 
@@ -57,6 +58,9 @@ class Shortcut:
         ...     return 'ok', 200
         >>> short.wire({'/my_route': ('short_ok', 200)})
     """
+
+    app: Optional[Flask]
+
     def __init__(self, app: Flask):
         if app.env not in _EXCLUDE:
             logger.info(f"Setting up flask shortcuts in environment '{app.env}'.")
@@ -64,7 +68,7 @@ class Shortcut:
             self.app = app
         else:
             # make .cut(...) return a wrapper that does nothing
-            self.cut = lambda mapping: lambda f: f
+            self.cut = MethodType(lambda mapping: lambda f: f, self)  # type: ignore
             self.app = None
 
     def cut(self, mapping: Union[RESPONSE_ARGS, Dict[str, RESPONSE_ARGS]]):

--- a/flask_shortcut/logic.py
+++ b/flask_shortcut/logic.py
@@ -8,67 +8,120 @@ from flask import request, Flask
 
 from flask_shortcut.util import diff, get_request_data
 
-PRODUCTION = "production"
+_EXCLUDE = ["production"]
 logger = getLogger(__name__)
+
+RESPONSE_ARGS = Tuple[Any, int]
 
 
 class Shortcut:
+    """Object that handles the shortcut rerouting.
+
+    Calling an instance of this class on a function gives that function the
+    option to behave differently in non-production environments. The way in
+    which the behavior may differ is constrained in two possible ways.
+
+    In the first one, only the arguments for a response are passed to the
+    shortcut definition, meaning that the original function is effectively
+    disabled and the route will instead just return the shortcut's arguments
+    as its only response.
+
+    In the second one, any number of shortcut response arguments are mapped
+    to condition-keys. The condition is a string that is used to assert a
+    substructure in requests that reach that route, and will only apply its
+    respective shortcut-response iff that substructure can be matched.
+
+    If none of the condition can be satisfied, the route will run its
+    original logic.
+
+    There are two different ways to register shortcuts, one using decorators
+    on the target functions before the are decorated as routes, and the
+    other by running the a single wire call after all routes were added.
+
+    Example:
+        Basic app setup:
+        >>> from flask import Flask
+        >>> from flask_shortcut import Shortcut
+        >>> app = Flask(__name__)
+        >>> short = Shortcut(app)
+
+        - With shortcut decorator:
+        >>> @app.route('/my_route', methods=['GET'])
+        ... @short.cut(('short_ok', 200))
+        ... def my_func():
+        ...     return 'ok', 200
+
+        - With post route-definition wiring:
+        >>> @app.route('/my_route', methods=['GET'])
+        ... def my_func():
+        ...     return 'ok', 200
+        >>> short.wire({'/my_route': ('short_ok', 200)})
+    """
     def __init__(self, app: Flask):
-        self.app = None
-        if app.env != PRODUCTION:
+        if app.env not in _EXCLUDE:
             logger.info(f"Setting up flask shortcuts in environment '{app.env}'.")
             secho("   Route shortcuts enabled. Do not do this in any kind of production environment.", fg="red")
             self.app = app
+        else:
+            # make .cut(...) return a wrapper that does nothing
+            self.cut = lambda mapping: lambda f: f
+            self.app = None
 
-    def __call__(self, mapping: Union[Tuple[Any, int], Dict[str, Tuple[Any, int]]]):
-        logger.debug(f"Registering shortcut with mapping of type '{type(mapping)}'.")
+    def cut(self, mapping: Union[RESPONSE_ARGS, Dict[str, RESPONSE_ARGS]]):
+        """Returns route wrappers.
 
-        # wrapper for simple tuple mappings
+        Depending on the input argument, a different wrapper will be returned.
+        This function can only run in applications that are not listed in the
+        `_EXCLUDE` list.
+
+        Args:
+            mapping: The mapping that decides which types of shortcuts can be
+                offered under which type of condition.
+        """
+        # wrapper in case only the response is given, assumes that the 'condition' is always True
         def simple_map(f):
             f_name = f"{f.__module__}.{f.__name__}"
-            logger.debug(f"Adding simple_map shortcut for routing function '{f_name}'.")
+            logger.info(f"Adding simple_map shortcut for routing function '{f_name}'.")
 
             @wraps(f)
-            def decorated(*args, **kwargs):
+            def decorated(*_, **__):
                 assert isinstance(mapping, tuple), "Messed up shortcut wiring, abort."  # nosec
-                if self.app.env != PRODUCTION:
-                    # 'condition' is assumed to be always True in this shortcut
-                    response, status = mapping
-                    return self.app.make_response(response), status
-                return f(*args, **kwargs)
+                logger.debug(f"Running shortcut for '{f_name}'.")
+
+                response, status = mapping
+                return self.app.make_response(response), status
 
             return decorated
 
         # wrapper for dict-based mappings
         def dict_map(f):
             f_name = f"{f.__module__}.{f.__name__}"
-            logger.debug(f"Adding dict_map shortcut for routing function '{f_name}'.")
+            logger.info(f"Adding dict_map shortcut for routing function '{f_name}'.")
 
             @wraps(f)
             def decorated(*args, **kwargs):
                 assert isinstance(mapping, dict), "Messed up shortcut wiring, abort."  # nosec
                 logger.debug(f"Running shortcut for '{f_name}'.")
 
-                if self.app.env != PRODUCTION:
-                    for condition, (response, status) in mapping.items():
-                        try:
-                            sub_resolves = diff(get_request_data(request), json.loads(condition))
-                        except TypeError as e:
-                            logger.debug(
-                                f"Couldn't walk '{condition}' in the target request, got error message '{str(e)}'. "
-                                f"This could mean that the shortcut for this function is not well-defined."
-                            )
-                            continue
-                        if not sub_resolves:
-                            continue
-                        return self.app.make_response(response), status
-                    else:
-                        logger.debug(f"Shortcut conditions couldn't be satisfied, defaulting to actual implementation.")
+                for condition, (response, status) in mapping.items():
+                    try:
+                        sub_resolves = diff(get_request_data(request), json.loads(condition))
+                    except TypeError as e:
+                        logger.debug(
+                            f"Couldn't walk '{condition}' in the target request, got error message '{str(e)}'. "
+                            f"This could mean that the shortcut for this function is not well-defined."
+                        )
+                        continue
+                    if not sub_resolves:
+                        continue
+                    return self.app.make_response(response), status
+                else:
+                    logger.debug(f"Shortcut conditions couldn't be satisfied, defaulting to actual implementation.")
                 return f(*args, **kwargs)
 
             return decorated
 
-        # auto-wiring the right decorator depending on mapping types
+        # assigning the right decorator depending on mapping types
         if isinstance(mapping, tuple):
             return simple_map
         elif isinstance(mapping, dict):
@@ -76,12 +129,24 @@ class Shortcut:
         else:
             raise TypeError(f"'{type(mapping)}' is not a supported mapping type for shortcuts yet.")
 
-    def wire(self, shortcuts=Dict[str, Union[Tuple, Dict]]):
+    def wire(self, shortcuts=Dict[str, Union[RESPONSE_ARGS, Dict[str, RESPONSE_ARGS]]]):
+        """Manual wiring functions.
+
+        If you don't want to have the shortcut definitions in your routing
+        file for some reason (e.g. there are lots of shortcuts and it would
+        make the whole thing hard to read), you can use this function at
+        some point after all routes were registered, and before the server
+        is started.
+
+        Args:
+            shortcuts: A dictionary that maps routes to the mappings that
+                would have been used as arguments in the shortcut decorator.
+        """
         route_map = {str(r): r.endpoint for r in self.app.url_map.iter_rules()}
 
-        for route in shortcuts:
+        for route, mapping in shortcuts.items():
             if route in route_map:
-                wrap = self(shortcuts[route])(self.app.view_functions[route_map[route]])
+                wrap = self.cut(mapping)(self.app.view_functions[route_map[route]])
                 self.app.view_functions[route_map[route]] = wrap
             else:
-                logger.warning(f"Can't resolve route '{route}' in the registered route '{[*route_map]}'")
+                logger.warning(f"Can't resolve route '{route}' in the registered routes '{[*route_map]}'")

--- a/flask_shortcut/util.py
+++ b/flask_shortcut/util.py
@@ -6,7 +6,7 @@ def get_request_data(r: Request):
     """Request data fetcher.
 
     This function inspects the mimetype in order to figure out how the data
-    can be represented in a standard python dictionary form.
+    can be represented in a standard python-dictionary form.
 
     Returns:
         The data in a form that sticks as close a parsed json object as possible, since
@@ -37,7 +37,7 @@ def diff(target, sub, path_=None) -> bool:
 
     Raises:
         TypeError: If the parse paths don't match, e.g. the target is a list
-            where the subtree expected to be a dictionary.
+            at a level where the subtree expected it to be a dictionary.
     """
     if path_ is None:
         path_ = ["root"]
@@ -59,5 +59,5 @@ def diff(target, sub, path_=None) -> bool:
                 continue
             return False
         return True
-    else:  # some kind of leaf, probably string, int, or float
+    else:  # some kind of leaf, i.e. string, int, bool, float, or None
         return bool(target == sub)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask_shortcut"
-version = "0.2.6"
+version = "0.3.0"
 description = "Extension that provides an easy way to add dev-only shortcuts to your routes."
 license = "MIT"
 authors = ["Arne <arecknag@gmail.com>"]


### PR DESCRIPTION
Took care of a bunch of smaller issues and added documentation, and fixed a big one.

I was really annoyed by the fact that the current implementation would
wrap the route functions in production as well, leading to some
shortcut artifacts being visible in stack traces and stuff. So I
added the skip to the `__init__` instead, which sadly meant that
I had to say goodbye to the cute `__call__`, since those can't
be patched on an instance level.